### PR TITLE
Support mysql

### DIFF
--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -57,6 +57,8 @@ RUN set -x \
         php7-pcntl      \
         php7-pdo_pgsql  \
         php7-pgsql      \
+        php7-pdo_mysql  \
+        php7-mysql      \
         php7-posix      \
         php7-session    \
       && curl -SL \


### PR DESCRIPTION
I've not been able to test this because i could not get `qemu-arm-static` working locally.

Anyhow when using mysql/mariadb I get the following error: PDOException: could not find driver in /configure-db.php:19 so I assume it's just because the mysql drivers are missing in the image.