### PR TITLE
fix(docs): remove usage of latest tag (unpredictive)

### DIFF
--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -24,7 +24,6 @@ jobs:
           calver="$(date +%Y.%m.%d)"
 
           docker build \
-            -t ${IMAGE_NAME}:latest \
             -t ${IMAGE_NAME}:${branch_name} \
             -t ${IMAGE_NAME}:${branch_name}-${calver} \
             -f Dockerfile.${ARCH} .

--- a/.github/workflows/release-arm32v6.yaml
+++ b/.github/workflows/release-arm32v6.yaml
@@ -32,7 +32,6 @@ jobs:
           tar zxvf qemu-arm-static.tar.gz
 
           docker build \
-            -t ${IMAGE_NAME}:latest \
             -t ${IMAGE_NAME}:${branch_name} \
             -t ${IMAGE_NAME}:${branch_name}-${calver} \
             -f Dockerfile.${ARCH} .

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ Host [Tiny Tiny RSS](https://tt-rss.org/) instance in a docker container support
 
 ## Available images and tags
 
-* **nventiveux/ttrss**
-  * *latest* ([Dockerfile.amd64](https://github.com/nVentiveUX/docker-ttrss/blob/master/Dockerfile.amd64))
+* **[nventiveux/ttrss](https://hub.docker.com/r/nventiveux/ttrss)** (x86_64)
+  * *master* ([Dockerfile.amd64](https://github.com/nVentiveUX/docker-ttrss/blob/master/Dockerfile.amd64))
+  * *develop* ([Dockerfile.amd64](https://github.com/nVentiveUX/docker-ttrss/blob/develop/Dockerfile.amd64))
 
-* **nventiveux/ttrss-arm32v6** (Raspberry Pi 2 / 3)
-  * *latest* ([Dockerfile.arm32v6](https://github.com/nVentiveUX/docker-ttrss/blob/master/Dockerfile.arm32v6))
+* **[nventiveux/ttrss-arm32v6](https://hub.docker.com/r/nventiveux/ttrss-arm32v6)** (Raspberry Pi 2 / 3)
+  * *master* ([Dockerfile.arm32v6](https://github.com/nVentiveUX/docker-ttrss/blob/master/Dockerfile.arm32v6))
+  * *develop* ([Dockerfile.arm32v6](https://github.com/nVentiveUX/docker-ttrss/blob/develop/Dockerfile.arm32v6))
 
 ## Usage
 


### PR DESCRIPTION
Prefer using the branch name like master / develop.