### PR TITLE
feat(ci): restore auto image refresh based on ttrss' upstream master

### DIFF
--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - "master"
       - "develop"
+  schedule:
+    - cron: '0 10 * * 6'
 
 jobs:
   docker_image:

--- a/.github/workflows/release-arm32v6.yaml
+++ b/.github/workflows/release-arm32v6.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - "master"
       - "develop"
+  schedule:
+    - cron: '0 10 * * 6'
 
 jobs:
   docker_image:


### PR DESCRIPTION
This add an auto build each saturday for the image based on the [latest upstream master](https://git.tt-rss.org/git/tt-rss) code. Use `master` (always latest) or `master-<YYYY.MM.DD>` tags to stick to a release.