### PR TITLE
Bump all gh-actions to solve deprecations in CI

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -8,11 +8,11 @@ on:
 jobs:
   auto_update:
     name: "Auto-update"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
 
     steps:
       - name: "Checkout project sources"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           token: "${{ secrets.RELEASE_PAT }}"
           ref: "${{ github.head_ref }}"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,34 +8,34 @@ on:
 jobs:
   lint:
     name: "Linting"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
 
       - name: "Lint Dockerfile"
-        uses: "hadolint/hadolint-action@v1.6.0"
+        uses: "hadolint/hadolint-action@v3.0.0"
         with:
           dockerfile: "Dockerfile"
 
   build:
     name: "Build"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
 
       - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@v1"
+        uses: "docker/setup-qemu-action@v2"
         with:
           platforms: "amd64,arm64,arm"
 
       - name: "Set up Docker Buildx"
         id: "buildx"
-        uses: "docker/setup-buildx-action@v1"
+        uses: "docker/setup-buildx-action@v2"
         with:
           install: true
 
       - name: "Build images"
-        uses: "docker/build-push-action@v2"
+        uses: "docker/build-push-action@v3"
         with:
           builder: "${{ steps.buildx.outputs.name }}"
           context: "."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,21 +8,21 @@ on:
 jobs:
   docker_image:
     name: "Docker image"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       IMAGE_NAME: "nventiveux/ttrss"
 
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
 
       - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@v1"
+        uses: "docker/setup-qemu-action@v2"
         with:
           platforms: "amd64,arm64,arm"
 
       - name: "Set up Docker Buildx"
         id: "buildx"
-        uses: "docker/setup-buildx-action@v1"
+        uses: "docker/setup-buildx-action@v2"
         with:
           install: true
 
@@ -39,13 +39,13 @@ jobs:
           echo "image_tags=${image_tags}" >> $GITHUB_OUTPUT
 
       - name: "Login to DockerHub"
-        uses: "docker/login-action@v1"
+        uses: "docker/login-action@v2"
         with:
           username: "${{ secrets.DOCKER_USERNAME }}"
           password: "${{ secrets.DOCKER_PASSWORD }}"
 
       - name: "Build images"
-        uses: "docker/build-push-action@v2"
+        uses: "docker/build-push-action@v3"
         with:
           builder: "${{ steps.buildx.outputs.name }}"
           context: "."
@@ -55,7 +55,7 @@ jobs:
           tags: "${{ steps.prep.outputs.image_tags }}"
 
       - name: "Update Docker Hub's README"
-        uses: "peter-evans/dockerhub-description@v2"
+        uses: "peter-evans/dockerhub-description@v3"
         with:
           username: "${{ secrets.DOCKER_USERNAME }}"
           password: "${{ secrets.DOCKER_PASSWORD }}"


### PR DESCRIPTION
```plain
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, docker/setup-qemu-action@v1, docker/setup-buildx-action@v1, docker/login-action@v1, docker/build-push-action@v2, peter-evans/dockerhub-description@v2
```