### PR TITLE
Add PATH_INFO support for APIs

### DIFF
--- a/nginx/conf.d/ttrss.conf
+++ b/nginx/conf.d/ttrss.conf
@@ -17,6 +17,15 @@ server {
     fastcgi_param PATH_INFO $fastcgi_path_info;
   }
 
+  location ~ /plugins\.local/.*/api/.*\.php(/|$) {
+    fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    fastcgi_pass localhost:9000;
+    fastcgi_index index.php;
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_param PATH_INFO $fastcgi_path_info;
+  }
+
   location /cache {
     deny all;
   }


### PR DESCRIPTION
Adding a pattern matching rule to enable PATH_INFO parameters to be passed to the backend server for plugins with "api" in their path.