### PR TITLE
Add simplexml php package to support cache_s3 plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN echo "➔ Installing system packages..." \
       php82-pgsql \
       php82-posix \
       php82-session \
+      php82-simplexml \
       php82-tokenizer \
       php82-xsl \
       supervisor \


### PR DESCRIPTION
The s3 plugin requires simplexml:
    https://git.tt-rss.org/fox/ttrss-cache-s3.git

